### PR TITLE
fix/LINK and Instagram

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -136,12 +136,12 @@ export default function AboutPage() {
                   <tr>
                     <th>SNS</th>
                     <td>
-                      <a
+                      <Link
                         href="https://www.instagram.com/fukunishi_farm/?igshid=MmIzYWVlNDQ5Yg%3D%3D"
                         target="_blank"
                       >
                         インスタグラム
-                      </a>
+                      </Link>
                     </td>
                   </tr>
                 </tbody>

--- a/app/download/page.tsx
+++ b/app/download/page.tsx
@@ -1,6 +1,7 @@
 import AppHeader from "../../components/AppHeader";
 import SiteFooter from "../../components/SiteFooter";
 import type { Metadata } from "next";
+import Link from "next/link";
 
 export const metadata: Metadata = {
   title: "ダウンロード資料",
@@ -15,15 +16,15 @@ export default function DownloadPage() {
         <h1>各種資料ダウンロード</h1>
         <h2>ちらし</h2>
         <p>
-          <a href="/PDF/R7_Pamphlet.pdf" target="_blank">R7_Pamphlet.pdf</a>
+          <Link href="/PDF/R7_Pamphlet.pdf" target="_blank">R7_Pamphlet.pdf</Link>
         </p>
         <h2>団体予約申込書</h2>
         <p>
-          <a href="/latex/fukunishifarm_FAX.pdf" target="_blank">fukunishifarm_FAX.pdf</a>
+          <Link href="/latex/fukunishifarm_FAX.pdf" target="_blank">fukunishifarm_FAX.pdf</Link>
         </p>
         <h2>地域別発送料</h2>
         <p>
-          <a href="/PDF/shipping_fee.pdf" target="_blank">shipping_fee.pdf</a>
+          <Link href="/PDF/shipping_fee.pdf" target="_blank">shipping_fee.pdf</Link>
         </p>
         <p><br /></p>
       </main>

--- a/app/news/page.tsx
+++ b/app/news/page.tsx
@@ -162,11 +162,14 @@ export default function NewsPage() {
           <h1>お知らせ</h1>
           <ul className="news-info inside">
             <li>
+              竜宝が終了いたしました。楽しみにしていただいた方には申し訳ありません。
+            </li>
+            <li>
               2025年8月24日より開園となります。ぜひぜひお越しください
             </li>
             <li>
               料金を変更させていただきました。詳しくは
-              <a href="/price">こちら</a>をご覧ください。
+              <Link href="/price">こちら</Link>をご覧ください。
             </li>
             <li>ホームページをリニューアルしました。</li>
           </ul>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@ import AppHeader from "../components/AppHeader";
 import SiteFooter from "../components/SiteFooter";
 import Image from "next/image";
 import type { Metadata } from "next";
+import Link from "next/link";
 
 export const metadata: Metadata = {
   title:
@@ -30,7 +31,7 @@ export default function Home() {
             <ul>
               <li>
                 料金を変更させていただきました。詳しくは
-                <a href="/price">こちら</a>をご覧ください。
+                <Link href="/price">こちら</Link>をご覧ください。
               </li>
             </ul>
           </div>
@@ -152,7 +153,7 @@ export default function Home() {
               <p className="under"></p>
               <p className="center">送料は別となっております。</p>
               <p className="center">
-                送料は<a href="/PDF/shipping_fee.pdf" target="_blank">こちら</a>をご覧ください。
+                送料は<Link href="/PDF/shipping_fee.pdf" target="_blank">こちら</Link>をご覧ください。
               </p>
               <p className="center">※竜宝の発送は承っておりません。</p>
             </div>
@@ -162,24 +163,14 @@ export default function Home() {
             <h2 className="font-english">Instagram</h2>
             <p className="center">
               Instagramのアカウントは
-              <a
+              <Link
                 href="https://www.instagram.com/fukunishi_farm/?igshid=MmIzYWVlNDQ5Yg%3D%3D"
                 target="_blank"
               >
                 こちら
-              </a>
+              </Link>
               をクリック。
             </p>
-            <h3>最新投稿</h3>
-            <div className="center">
-              <p>現在準備中です</p>
-              <a
-                href="https://www.instagram.com/fukunishi_farm/?igshid=MmIzYWVlNDQ5Yg%3D%3D"
-                target="_blank"
-              >
-                アカウントをご覧ください
-              </a>
-            </div>
           </div>
         </div>
       </main>


### PR DESCRIPTION
## 💻概要
### 機能名
URLリンクの修正およびInstagramの最新投稿表示欄の削除

## 📄修正内容
URLリンクをaタグで直接記載していたものをLINKタブに修正
Instagramの最新投稿表示欄を削除

## 👀動作確認
各種URLリンクが動作するかを確認
